### PR TITLE
Added Azure Blob Storage SAS URI analysis and parsing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,12 @@ If you are frustrated by this process, often repeated multiple times a day, then
 
 ---    
 ### Features
-- Offline parsing to keep your URL and Params confidential
-- Allows you to pipe-in the url from the command line via stdin
-- [*New Feature] Check the final destination (after redirects) of a URL
-- [*New Feature] **Proxy** (`-p`) to allow to forward proxy the traffic for further inspection to Burp (or your proxy of choice) 
+- Offline parsing to keep your URL and Query String Parameters confidential.
+- Allows you to pipe-in (`|`) the URL from the command line via `stdin`.
+- Check the final destination (`-f`) after redirects of a URL.
+- **Proxy** (`-p`) to allow to forward proxy the traffic for further inspection to Burp (or your proxy of choice)  . 
+- Check Azure Blob Storage SAS URIs (`sas`) for type & parse the parameters with details of what each of those parameters mean in long form.
+- Parse cookies 🍪 with `-c`.
 
 ---    
 ## Example use cases:

--- a/urlyzer.go
+++ b/urlyzer.go
@@ -225,11 +225,11 @@ func identifySASURIType(queryParams url.Values) string {
 
 func getLongForm(sasType, key, value string) (string, string) {
 	switch sasType {
-	case "AccountSAS":
+	case "Account SAS URI":
 		return getLongFormAccountSAS(key, value)
-	case "ServiceSAS":
+	case "Service SAS URI":
 		return getLongFormServiceSAS(key, value)
-	case "DelegationSAS":
+	case "Delegation SAS URI":
 		return getLongFormDelegationSAS(key, value)
 	default:
 		return key, value // If the SAS type is unknown, return the original key and value

--- a/urlyzer.go
+++ b/urlyzer.go
@@ -69,12 +69,12 @@ func main() {
 		values := parsedURL.Query()
 		// Identify the type of SAS URI
 		sasType := identifySASURIType(values)
-		fmt.Printf("\033[31mSAS URI Type: %s\033[0m\n", sasType)
+		fmt.Printf("%sSAS URI Type:%s %s\n", Red, Green, sasType)
 
 		// Print the parsed query parameters
 		for key, value := range values {
 			longFormName, longFormValue := getLongForm(sasType, key, value[0]) // Assuming each key has only one value
-			fmt.Printf("%s=%s\t||\t%s = %s\n", key, value[0], longFormName, longFormValue)
+			fmt.Printf("   %s%s=%s%s   %s||%s  %s=%s%s\n", Cyan, key, Yellow, value[0], Reset, Cyan, longFormName, Yellow, longFormValue)
 		}
 	} else if *checkFinalURLDestination {
 		finalDestination, headers, statusCode, err := getFinalDestination(proxyURL, inputURL)


### PR DESCRIPTION
Added parsing of Azure Blob Storage SAS URIs with the `sas` flag. This feature analyzes what type of SAS URI it might be as well as parsing the parameters and mapping them to their long form, so it is easier to visualize what access & permissions it has.

I also updated the `README.md` to add awareness of the new Cookie 🍪 parsing feature with `-c` flag.